### PR TITLE
refactor: Use projection to return only required property fields

### DIFF
--- a/src/main/java/com/example/awaas/controllers/PropertyController.java
+++ b/src/main/java/com/example/awaas/controllers/PropertyController.java
@@ -40,7 +40,6 @@ public class PropertyController {
         }
     }
 
-
     @PutMapping("/{id}")
     public ResponseEntity<?> editProperty(
             @PathVariable Long id,
@@ -58,16 +57,16 @@ public class PropertyController {
 
     @GetMapping
     public ResponseEntity<?> getAllProperties(
-            @RequestParam(required = false) String location,   // Optional location filter
-            @RequestParam(required = false) Double minPrice,   // Optional minimum price filter
-            @RequestParam(required = false) Double maxPrice,   // Optional maximum price filter
+            @RequestParam(required = false) String location, // Optional location filter
+            @RequestParam(required = false) Double minPrice, // Optional minimum price filter
+            @RequestParam(required = false) Double maxPrice, // Optional maximum price filter
             @RequestParam(required = false) PropertyTypeEnum type, // Optional property type filter
-            @RequestParam(defaultValue = "0") int page,        // Default page number
-            @RequestParam(defaultValue = "10") int size        // Default page size
+            @RequestParam(defaultValue = "0") int page, // Default page number
+            @RequestParam(defaultValue = "10") int size // Default page size
     ) {
         try {
-            Page<PropertyResponse> properties = propertyService.getAllProperties(location, minPrice, maxPrice, type, page, size);
-            return ResponseEntity.ok(properties);
+            return ResponseEntity.ok(propertyService.getAllProperties(location, minPrice, maxPrice, type, page, size));
+
         } catch (Exception e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         }

--- a/src/main/java/com/example/awaas/managers/PropertyManager.java
+++ b/src/main/java/com/example/awaas/managers/PropertyManager.java
@@ -5,7 +5,9 @@ import com.example.awaas.dtos.UserDTO;
 import com.example.awaas.entities.Property;
 import com.example.awaas.enums.PropertyTypeEnum;
 import com.example.awaas.mappers.PropertyMapper;
+import com.example.awaas.projections.PropertyProjection;
 import com.example.awaas.repos.PropertyRepo;
+import com.example.awaas.response.PropertyProjectionResponse;
 import com.example.awaas.response.PropertyResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -38,12 +40,14 @@ public class PropertyManager {
         return null;
     }
 
-    public Page<PropertyResponse> getAllProperties(String location, Double minPrice, Double maxPrice, PropertyTypeEnum type, int page, int size) {
+    public Page<PropertyProjectionResponse> getAllProperties(String location, Double minPrice, Double maxPrice,
+            PropertyTypeEnum type, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<Property> propertyPage = propertyRepository.findAllWithFilters(location, minPrice, maxPrice, type, pageable);
+        Page<PropertyProjection> propertyPage = propertyRepository.findAllWithFilters(location, minPrice, maxPrice,
+                type, pageable);
 
-        // Map the Page<Property> to Page<PropertyResponse>
-        return PropertyMapper.INSTANCE.toPagePropertyResponse(propertyPage);
+        // Map the Page<PropertyProjection> to Page<PropertyProjectionResponse>
+        return PropertyMapper.INSTANCE.toPagePropertyProjectionResponse(propertyPage);
     }
 
     public List<PropertyDTO> getPropertiesByOwner(Long ownerId) {

--- a/src/main/java/com/example/awaas/mappers/PropertyMapper.java
+++ b/src/main/java/com/example/awaas/mappers/PropertyMapper.java
@@ -2,7 +2,9 @@ package com.example.awaas.mappers;
 
 import com.example.awaas.dtos.PropertyDTO;
 import com.example.awaas.entities.Property;
+import com.example.awaas.projections.PropertyProjection;
 import com.example.awaas.requests.CreatePropertyRequest;
+import com.example.awaas.response.PropertyProjectionResponse;
 import com.example.awaas.response.PropertyResponse;
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
@@ -15,9 +17,13 @@ public interface PropertyMapper {
     PropertyMapper INSTANCE = Mappers.getMapper(PropertyMapper.class);
 
     Property toEntity(PropertyDTO dto);
+
     PropertyDTO toPropertyDTO(Property property);
+
     PropertyDTO toPropertyDTO(CreatePropertyRequest createPropertyRequest);
+
     PropertyResponse toPropertyResponse(PropertyDTO propertyDTO);
+
     // Custom method to map Page<Property> to Page<PropertyResponse>
     default Page<PropertyResponse> toPagePropertyResponse(Page<Property> propertyPage) {
         return propertyPage.map(this::toPropertyResponseFromEntity);
@@ -27,5 +33,14 @@ public interface PropertyMapper {
     PropertyResponse toPropertyResponseFromEntity(Property property);
 
     List<PropertyDTO> toPropertyDTOList(List<Property> propertyList);
+
     List<PropertyResponse> toPropertyResponseList(List<PropertyDTO> properties);
+
+    // projection method
+    PropertyProjectionResponse toResponse(PropertyProjection projection);
+
+    default Page<PropertyProjectionResponse> toPagePropertyProjectionResponse(
+            Page<PropertyProjection> propertyProjection) {
+        return propertyProjection.map(this::toResponse);
+    }
 }

--- a/src/main/java/com/example/awaas/projections/PropertyProjection.java
+++ b/src/main/java/com/example/awaas/projections/PropertyProjection.java
@@ -1,0 +1,15 @@
+package com.example.awaas.projections;
+
+import com.example.awaas.enums.PropertyTypeEnum;
+
+public interface PropertyProjection {
+    Long getId();
+
+    String getTitle();
+
+    Double getPrice();
+
+    String getLocation();
+
+    PropertyTypeEnum getType();
+}

--- a/src/main/java/com/example/awaas/repos/PropertyRepo.java
+++ b/src/main/java/com/example/awaas/repos/PropertyRepo.java
@@ -2,6 +2,8 @@ package com.example.awaas.repos;
 
 import com.example.awaas.entities.Property;
 import com.example.awaas.enums.PropertyTypeEnum;
+import com.example.awaas.projections.PropertyProjection;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,17 +13,17 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface PropertyRepo extends JpaRepository<Property, Long> {
-    @Query("SELECT p FROM Property p WHERE " +
-            "(:location IS NULL OR p.location LIKE %:location%) AND " +
-            "(:minPrice IS NULL OR p.price >= :minPrice) AND " +
-            "(:maxPrice IS NULL OR p.price <= :maxPrice) AND " +
-            "(:type IS NULL OR p.type = :type)")
-    Page<Property> findAllWithFilters(
-            @Param("location") String location,
-            @Param("minPrice") Double minPrice,
-            @Param("maxPrice") Double maxPrice,
-            @Param("type") PropertyTypeEnum type,
-            Pageable pageable);
+        @Query("SELECT p FROM Property p WHERE " +
+                        "(:location IS NULL OR p.location LIKE %:location%) AND " +
+                        "(:minPrice IS NULL OR p.price >= :minPrice) AND " +
+                        "(:maxPrice IS NULL OR p.price <= :maxPrice) AND " +
+                        "(:type IS NULL OR p.type = :type)")
+        Page<PropertyProjection> findAllWithFilters(
+                        @Param("location") String location,
+                        @Param("minPrice") Double minPrice,
+                        @Param("maxPrice") Double maxPrice,
+                        @Param("type") PropertyTypeEnum type,
+                        Pageable pageable);
 
-    List<Property> findByOwnerId(Long ownerId);
+        List<Property> findByOwnerId(Long ownerId);
 }

--- a/src/main/java/com/example/awaas/response/PropertyProjectionResponse.java
+++ b/src/main/java/com/example/awaas/response/PropertyProjectionResponse.java
@@ -1,0 +1,60 @@
+package com.example.awaas.response;
+
+public class PropertyProjectionResponse {
+    private Long id;
+    private String title;
+    private String location;
+    private Double price;
+    private String type;
+
+    public PropertyProjectionResponse() {
+    }
+
+    public PropertyProjectionResponse(Long id, String title, String location, Double price, String type) {
+        this.id = id;
+        this.title = title;
+        this.location = location;
+        this.price = price;
+        this.type = type;
+    }
+
+    public Long getId() {
+        return this.id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return this.title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getLocation() {
+        return this.location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+    public Double getPrice() {
+        return this.price;
+    }
+
+    public void setPrice(Double price) {
+        this.price = price;
+    }
+
+    public String getType() {
+        return this.type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+}

--- a/src/main/java/com/example/awaas/services/PropertyService.java
+++ b/src/main/java/com/example/awaas/services/PropertyService.java
@@ -7,6 +7,7 @@ import com.example.awaas.managers.PropertyManager;
 import com.example.awaas.managers.UserManager;
 import com.example.awaas.mappers.PropertyMapper;
 import com.example.awaas.requests.CreatePropertyRequest;
+import com.example.awaas.response.PropertyProjectionResponse;
 import com.example.awaas.response.PropertyResponse;
 import com.example.awaas.utilities.EmailUtility;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,7 +34,8 @@ public class PropertyService {
     // Path to save uploaded images locally (adjust as needed)
     private final String UPLOAD_DIR = "/Users/omrajsharma/Documents/coding-ninjas/cn-awaas-vishwa-spring-be/uploads/";
 
-    public PropertyResponse createProperty(CreatePropertyRequest request, MultipartFile image, String ownerEmail) throws IOException {
+    public PropertyResponse createProperty(CreatePropertyRequest request, MultipartFile image, String ownerEmail)
+            throws IOException {
         // Find owner by email
         UserDTO owner = userManager.getByEmail(ownerEmail);
         if (owner == null) {
@@ -72,7 +74,6 @@ public class PropertyService {
         return PropertyMapper.INSTANCE.toPropertyResponse(propertyManager.save(propertyDTO));
     }
 
-
     public PropertyResponse editProperty(Long propertyId, CreatePropertyRequest request, String ownerEmail) {
         // Find the property by ID
         PropertyDTO property = propertyManager.findById(propertyId);
@@ -98,7 +99,8 @@ public class PropertyService {
     }
 
     // Get all properties with pagination
-    public Page<PropertyResponse> getAllProperties(String location, Double minPrice, Double maxPrice, PropertyTypeEnum type, int page, int size) {
+    public Page<PropertyProjectionResponse> getAllProperties(String location, Double minPrice, Double maxPrice,
+            PropertyTypeEnum type, int page, int size) {
         return propertyManager.getAllProperties(location, minPrice, maxPrice, type, page, size);
     }
 


### PR DESCRIPTION
#### Summary
- Implemented a **projection** to optimize property retrieval by returning only required fields.  
- This reduces unnecessary data transfer and improves performance.  

#### Changes Made  
- **Created a projection** to fetch only the following fields:  
  - `id`  
  - `title`  
  - `location`  
  - `price`  
  - `type`  
- Updated the relevant repository, mapper, manager, service to use this projection.  

#### Impact 
- Improves API efficiency by excluding unnecessary fields.  
- Reduces payload size and enhances response time.  

#### Testing & Verification 
- Verified that API now returns only the required fields.